### PR TITLE
start/stop outgoing peering function added to peers menu

### DIFF
--- a/internal/tray-agent/agent/client/peerings.go
+++ b/internal/tray-agent/agent/client/peerings.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"errors"
+	discovery "github.com/liqotech/liqo/apis/discovery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//StartStopOutPeering interacts with a ForeignCluster to trigger the procedure to establish a peering towards
+//a peer (start = true) or to stop it if already active.
+func (ctrl *AgentController) StartStopOutPeering(foreignCluster string, start bool) error {
+	fcCtrl := ctrl.Controller(CRForeignCluster)
+	obj, exist, err := fcCtrl.Store.GetByKey(foreignCluster)
+	if err != nil {
+		return err
+	}
+	if !exist {
+		return errors.New("no such ForeignCluster found")
+	}
+	fc := obj.(*discovery.ForeignCluster)
+	fc.Spec.Join = start
+	_, err = fcCtrl.Resource(string(CRForeignCluster)).Update(foreignCluster, fc, metav1.UpdateOptions{})
+	return err
+}

--- a/internal/tray-agent/agent/logic/listeners.go
+++ b/internal/tray-agent/agent/logic/listeners.go
@@ -30,7 +30,7 @@ func listenNewPeer(data client.NotifyDataGeneric, _ ...interface{}) {
 		return
 	}
 	//create a new entry in the dynamic list of the peer menu
-	newPeerNode := createPeerNode(quickNode, fcData)
+	newPeerNode := createPeerNode(quickNode, fcData, peer)
 	//refresh content of the tray menu entry
 	wg := &sync.WaitGroup{}
 	wg.Add(2)

--- a/internal/tray-agent/app-indicator/status.go
+++ b/internal/tray-agent/app-indicator/status.go
@@ -213,8 +213,10 @@ type Status struct {
 
 //PeerInfo contains some basic information on a peer.
 type PeerInfo struct {
-	ClusterID   string
-	ClusterName string
+	//ForeignClusterResourceName identifies the name of the associated ForeignCluster CRD.
+	ForeignClusterResourceName string
+	ClusterID                  string
+	ClusterName                string
 	//Unknown identifies whether the peer has no provided ClusterName.
 	//In this case, UnknownId contains a valid serial identifier.
 	Unknown bool
@@ -274,9 +276,10 @@ func (st *Status) AddPeer(data *client.NotifyDataForeignCluster) *PeerInfo {
 		panic("clusterId of a NotifyDataForeignCluster object should always be not empty")
 	}
 	peer := &PeerInfo{
-		ClusterID:           data.ClusterID,
-		OutPeeringConnected: data.OutPeering.Connected,
-		InPeeringConnected:  data.InPeering.Connected,
+		ForeignClusterResourceName: data.Name,
+		ClusterID:                  data.ClusterID,
+		OutPeeringConnected:        data.OutPeering.Connected,
+		InPeeringConnected:         data.InPeering.Connected,
 	}
 	st.Lock()
 	defer st.Unlock()


### PR DESCRIPTION
# Description

This PR adds to the peers menu the logic to perform the start / stop of a peering towards another foreign cluster.