### PR TITLE
Fix Peer add/update event handling

### DIFF
--- a/internal/tray-agent/agent/client/notifyChannels.go
+++ b/internal/tray-agent/agent/client/notifyChannels.go
@@ -8,18 +8,15 @@ type NotifyChannel int
 
 //NotifyChannel identifiers.
 const (
-	//Notification channel id for the addition of a new peer discovered.
-	ChanPeerAdded NotifyChannel = iota
+	//Notification channel id for an update of an available peer.
+	ChanPeerAddedOrUpdated NotifyChannel = iota
 	//Notification channel id for the removal of an available peer.
 	ChanPeerDeleted
-	//Notification channel id for an update of an available peer.
-	ChanPeerUpdated
 )
 
 //notifyChannelNames contains all the registered NotifyChannel managed by the AgentController.
 //It is used for init and testing purposes.
 var notifyChannelNames = []NotifyChannel{
-	ChanPeerAdded,
+	ChanPeerAddedOrUpdated,
 	ChanPeerDeleted,
-	ChanPeerUpdated,
 }

--- a/internal/tray-agent/agent/logic/listeners.go
+++ b/internal/tray-agent/agent/logic/listeners.go
@@ -10,7 +10,7 @@ import (
 
 //******* PEERS *******
 
-func listenNewPeer(data client.NotifyDataGeneric, _ ...interface{}) {
+func listenAddedOrUpdatedPeer(data client.NotifyDataGeneric, _ ...interface{}) {
 	i := app.GetIndicator()
 	status := i.Status()
 	fcData, ok := data.(*client.NotifyDataForeignCluster)
@@ -18,45 +18,7 @@ func listenNewPeer(data client.NotifyDataGeneric, _ ...interface{}) {
 		panic("wrong NotifyData type for an event Listener")
 	}
 	//1- store information on Indicator Status
-	peer := status.AddPeer(fcData)
-	peer.RLock()
-	defer peer.RUnlock()
-	//update content of the Status MenuNode in the tray menu
-	i.RefreshStatus()
-
-	//2- update information on tray menu
-	quickNode, present := i.Quick(qPeers)
-	if !present {
-		return
-	}
-	//create a new entry in the dynamic list of the peer menu
-	newPeerNode := createPeerNode(quickNode, fcData, peer)
-	//refresh content of the tray menu entry
-	wg := &sync.WaitGroup{}
-	wg.Add(2)
-	go refreshPeerInfo(newPeerNode, peer, fcData, wg)
-	go refreshPeeringInfo(newPeerNode, peer, fcData, wg)
-	wg.Wait()
-	refreshPeerCount(quickNode)
-
-	//3- notify selected events
-	if peer.OutPeeringConnected {
-		i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOn, peer)
-	}
-	if peer.InPeeringConnected {
-		i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOn, peer)
-	}
-}
-
-func listenUpdatedPeer(data client.NotifyDataGeneric, _ ...interface{}) {
-	i := app.GetIndicator()
-	status := i.Status()
-	fcData, ok := data.(*client.NotifyDataForeignCluster)
-	if !ok {
-		panic("wrong NotifyData type for an event Listener")
-	}
-	//1- update peer data
-	peer := status.UpdatePeer(fcData)
+	peer := status.AddOrUpdatePeer(fcData)
 	peer.RLock()
 	defer peer.RUnlock()
 	//update content of the Status MenuNode in the tray menu
@@ -68,28 +30,36 @@ func listenUpdatedPeer(data client.NotifyDataGeneric, _ ...interface{}) {
 		return
 	}
 	peerNode, present := quickNode.ListChild(peer.ClusterID)
-	if present {
-		//refresh content of the tray menu entry
-		wg := &sync.WaitGroup{}
-		wg.Add(2)
-		go refreshPeerInfo(peerNode, peer, fcData, wg)
-		go refreshPeeringInfo(peerNode, peer, fcData, wg)
-		wg.Wait()
+	if !present {
+		peerNode = createPeerNode(quickNode, fcData, peer)
 	}
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go refreshPeerInfo(peerNode, peer, fcData, wg)
+	go refreshPeeringInfo(peerNode, peer, fcData, wg)
+	wg.Wait()
 	refreshPeerCount(quickNode)
 
 	//3- notify selected events
-	if !fcData.OutPeering.Connected && peer.OutPeeringConnected {
-		i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOn, peer)
-	} else if fcData.OutPeering.Connected && !peer.OutPeeringConnected {
-		i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOff, peer)
+	if !present {
+		if peer.OutPeeringConnected {
+			i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOn, peer)
+		}
+		if peer.InPeeringConnected {
+			i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOn, peer)
+		}
+	} else {
+		if !fcData.OutPeering.Connected && peer.OutPeeringConnected {
+			i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOn, peer)
+		} else if fcData.OutPeering.Connected && !peer.OutPeeringConnected {
+			i.NotifyPeering(app.PeeringOutgoing, app.NotifyEventPeeringOff, peer)
+		}
+		if !fcData.InPeering.Connected && peer.InPeeringConnected {
+			i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOn, peer)
+		} else if fcData.InPeering.Connected && !peer.InPeeringConnected {
+			i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOff, peer)
+		}
 	}
-	if !fcData.InPeering.Connected && peer.InPeeringConnected {
-		i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOn, peer)
-	} else if fcData.InPeering.Connected && !peer.InPeeringConnected {
-		i.NotifyPeering(app.PeeringIncoming, app.NotifyEventPeeringOff, peer)
-	}
-
 }
 
 func listenDeletedPeer(data client.NotifyDataGeneric, _ ...interface{}) {

--- a/internal/tray-agent/agent/logic/logic_test.go
+++ b/internal/tray-agent/agent/logic/logic_test.go
@@ -40,10 +40,8 @@ func TestOnReady(t *testing.T) {
 	// test Listeners registrations
 
 	// test peers Listeners
-	_, exist = i.Listener(client.ChanPeerAdded)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeerAdded not registered")
-	_, exist = i.Listener(client.ChanPeerUpdated)
-	assert.True(t, exist, "Listener for NotifyChanType ChanPeerUpdated not registered")
+	_, exist = i.Listener(client.ChanPeerAddedOrUpdated)
+	assert.True(t, exist, "Listener for NotifyChanType ChanPeerAddedOrUpdated not registered")
 	_, exist = i.Listener(client.ChanPeerDeleted)
 	assert.True(t, exist, "Listener for NotifyChanType ChanPeerDeleted not registered")
 }

--- a/internal/tray-agent/agent/logic/managers.go
+++ b/internal/tray-agent/agent/logic/managers.go
@@ -87,7 +87,6 @@ func startQuickShowPeers(i *app.Indicator) {
   Since these listeners work on a specific QUICK MenuNode, the associated handlers works only if that QUICK
   is registered in the Indicator.*/
 func startListenerPeersList(i *app.Indicator) {
-	i.Listen(client.ChanPeerAdded, listenNewPeer)
-	i.Listen(client.ChanPeerUpdated, listenUpdatedPeer)
+	i.Listen(client.ChanPeerAddedOrUpdated, listenAddedOrUpdatedPeer)
 	i.Listen(client.ChanPeerDeleted, listenDeletedPeer)
 }


### PR DESCRIPTION
# Description

This PR fixes the handling of *peer added* and *peer updated* events by unifying the two pipelines of event handling by means of:

- unique *NotifyChannel*
- unique Indicator.*Listener* 
- unique Indicator.*Status* method
- unique helper function in the *agent/logic* package

This way it is possible to avoid some corner cases involving the k8s *Store* of the Liqo ForeignCluster *CRDClient* where the handler of an update can not react in any other way than **panic**ing in case of a miss in the peers db inside the Indicator.*Status*.